### PR TITLE
Switch theme

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next"
 import { Geist, Geist_Mono } from "next/font/google"
-
+import CssBaseline from "@mui/material/CssBaseline"
+import MuiRegistry from "./mui-registry"
 const geistSans = Geist({
   variable: "--font-geist-sans",
   subsets: ["latin"],
@@ -26,7 +27,10 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <MuiRegistry>
+          <CssBaseline />
+          {children}
+        </MuiRegistry>
       </body>
     </html>
   )

--- a/src/app/mui-registry.tsx
+++ b/src/app/mui-registry.tsx
@@ -1,0 +1,17 @@
+// app/mui-registry.tsx
+"use client"
+
+import { CacheProvider } from "@emotion/react"
+import { createEmotionCache } from "@/utils/emotion-cache"
+import { ReactNode } from "react"
+import { ThemeProvider } from "@/design-system/theme/ThemeProvider"
+
+const emotionCache = createEmotionCache()
+
+export default function MuiRegistry({ children }: { children: ReactNode }) {
+  return (
+    <CacheProvider value={emotionCache}>
+      <ThemeProvider>{children}</ThemeProvider>
+    </CacheProvider>
+  )
+}

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,15 @@
+"use client"
+import { useThemeMode } from "@/design-system/theme/ThemeProvider"
+import { IconButton } from "@mui/material"
+import DarkModeIcon from "@mui/icons-material/DarkMode"
+import LightModeIcon from "@mui/icons-material/LightMode"
+
+export function ThemeToggleButton() {
+  const { mode, toggleTheme } = useThemeMode()
+
+  return (
+    <IconButton onClick={toggleTheme} color="inherit">
+      {mode === "light" ? <DarkModeIcon /> : <LightModeIcon />}
+    </IconButton>
+  )
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,8 +1,10 @@
 import ButtonAppBar from "@/design-system/components/AppBar"
+import React from "react"
 
-export default function Home() {
+export default function Header() {
   return (
-    <div>
+    <div className="">
+      <div>Header</div>
       <ButtonAppBar />
     </div>
   )

--- a/src/components/tabs/HeaderCustomTabPanel.tsx
+++ b/src/components/tabs/HeaderCustomTabPanel.tsx
@@ -1,0 +1,29 @@
+"use client"
+import * as React from "react"
+import Box from "@mui/material/Box"
+import Tabs from "@mui/material/Tabs"
+import Tab from "@mui/material/Tab"
+import { useState } from "react"
+
+export default function HeaderCustomTabPanel() {
+  const [value, setValue] = useState(0)
+
+  const handleChange = (event: React.SyntheticEvent, newValue: number) => {
+    setValue(newValue)
+  }
+
+  return (
+    <Box sx={{ width: "100%", bgcolor: "background.transparent" }}>
+      <Tabs
+        value={value}
+        onChange={handleChange}
+        indicatorColor="secondary"
+        textColor="inherit"
+        centered
+      >
+        <Tab label="GERAL" />
+        <Tab label="ESTAÇÃO" />
+      </Tabs>
+    </Box>
+  )
+}

--- a/src/design-system/components/AppBar.tsx
+++ b/src/design-system/components/AppBar.tsx
@@ -1,0 +1,22 @@
+import * as React from "react"
+import AppBar from "@mui/material/AppBar"
+import Box from "@mui/material/Box"
+import Toolbar from "@mui/material/Toolbar"
+
+import CloudIcon from "@mui/icons-material/Cloud"
+import HeaderCustomTabPanel from "@/components/tabs/HeaderCustomTabPanel"
+import { ThemeToggleButton } from "@/components/ThemeToggle"
+
+export default function ButtonAppBar() {
+  return (
+    <Box sx={{ flexGrow: 1 }}>
+      <AppBar position="static" color="primary">
+        <Toolbar>
+          <CloudIcon />
+          <HeaderCustomTabPanel />
+          <ThemeToggleButton />
+        </Toolbar>
+      </AppBar>
+    </Box>
+  )
+}

--- a/src/design-system/components/Button.tsx
+++ b/src/design-system/components/Button.tsx
@@ -1,0 +1,16 @@
+// design-system/components/Button.tsx
+import { Button as MUIButton, ButtonProps } from "@mui/material"
+import clsx from "clsx"
+
+interface CustomButtonProps extends ButtonProps {
+  className?: string
+}
+
+export function Button({ className, ...props }: CustomButtonProps) {
+  return (
+    <MUIButton
+      {...props}
+      className={clsx("rounded-md font-bold normal-case", className || "")}
+    />
+  )
+}

--- a/src/design-system/theme/ThemeProvider.tsx
+++ b/src/design-system/theme/ThemeProvider.tsx
@@ -1,0 +1,39 @@
+// design-system/theme/ThemeProvider.tsx
+"use client"
+
+import { createContext, useContext, useMemo, useState } from "react"
+import { ThemeProvider as MuiThemeProvider } from "@mui/material/styles"
+import { CssBaseline } from "@mui/material"
+import { createMuiTheme } from "./create-mui-theme"
+
+type ThemeMode = "light" | "dark"
+
+interface ThemeContextType {
+  mode: ThemeMode
+  toggleTheme: () => void
+}
+
+const ThemeContext = createContext<ThemeContextType>({
+  mode: "light",
+  toggleTheme: () => {},
+})
+
+export const useThemeMode = () => useContext(ThemeContext)
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [mode, setMode] = useState<ThemeMode>("light")
+
+  const toggleTheme = () =>
+    setMode((prev) => (prev === "light" ? "dark" : "light"))
+
+  const theme = useMemo(() => createMuiTheme(mode), [mode])
+
+  return (
+    <ThemeContext.Provider value={{ mode, toggleTheme }}>
+      <MuiThemeProvider theme={theme}>
+        <CssBaseline />
+        {children}
+      </MuiThemeProvider>
+    </ThemeContext.Provider>
+  )
+}

--- a/src/utils/emotion-cache.ts
+++ b/src/utils/emotion-cache.ts
@@ -1,0 +1,7 @@
+// utils/emotion-cache.ts
+"use client" // necessário se for usado também no cliente
+
+import createCache from "@emotion/cache"
+
+export const createEmotionCache = () =>
+  createCache({ key: "css", prepend: true })


### PR DESCRIPTION
This pull request introduces Material-UI (MUI) to the project, implementing a design system with theming, reusable components, and layout updates. Key changes include setting up a theme provider, creating custom components, and integrating a new app bar with theming and tab navigation.

### Integration of Material-UI (MUI):

* [`src/app/layout.tsx`](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3L3-R4): Added `CssBaseline` and wrapped the application in a new `MuiRegistry` component to enable MUI theming and styling. (`[[1]](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3L3-R4)`, `[[2]](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3R30-R33)`)
* [`src/app/mui-registry.tsx`](diffhunk://#diff-19e9c94a33e33318dc5d84b6db5cb592b10c3f6a1bbaf28657e328b8f3a15025R1-R17): Introduced the `MuiRegistry` component, which provides Emotion cache and theme context using MUI's `CacheProvider` and `ThemeProvider`. (`[src/app/mui-registry.tsxR1-R17](diffhunk://#diff-19e9c94a33e33318dc5d84b6db5cb592b10c3f6a1bbaf28657e328b8f3a15025R1-R17)`)

### Theming and Theme Management:

* [`src/design-system/theme/ThemeProvider.tsx`](diffhunk://#diff-9408b86c5db9cfa5c49c54990c93d453c4bf8285cf7d182705d0d0bb0feb7062R1-R39): Created a `ThemeProvider` component to manage light and dark theme modes, along with a context for toggling themes. (`[src/design-system/theme/ThemeProvider.tsxR1-R39](diffhunk://#diff-9408b86c5db9cfa5c49c54990c93d453c4bf8285cf7d182705d0d0bb0feb7062R1-R39)`)
* [`src/components/ThemeToggle.tsx`](diffhunk://#diff-5cd95420755f79ed0fcea438247ffa21c249ddb1d277ec2d9333798bc18edbd0R1-R15): Added a `ThemeToggleButton` component for switching between light and dark modes using the theme context. (`[src/components/ThemeToggle.tsxR1-R15](diffhunk://#diff-5cd95420755f79ed0fcea438247ffa21c249ddb1d277ec2d9333798bc18edbd0R1-R15)`)

### New Design System Components:

* [`src/design-system/components/AppBar.tsx`](diffhunk://#diff-df0f7e562bfc5f9ceac741a846b6971f706202933639811d37188ed40ea6951bR1-R22): Implemented a custom app bar (`ButtonAppBar`) with a cloud icon, tab navigation, and a theme toggle button. (`[src/design-system/components/AppBar.tsxR1-R22](diffhunk://#diff-df0f7e562bfc5f9ceac741a846b6971f706202933639811d37188ed40ea6951bR1-R22)`)
* [`src/design-system/components/Button.tsx`](diffhunk://#diff-3e6aee06bfb740a3364c4f6434c93058f211957cae4a242f1258667b6b7819b8R1-R16): Created a reusable `Button` component that extends MUI's `Button` with additional styling. (`[src/design-system/components/Button.tsxR1-R16](diffhunk://#diff-3e6aee06bfb740a3364c4f6434c93058f211957cae4a242f1258667b6b7819b8R1-R16)`)

### Layout and Navigation Updates:

* [`src/app/page.tsx`](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bR1-R6): Replaced the placeholder content with the new `ButtonAppBar` component for the main page layout. (`[src/app/page.tsxR1-R6](diffhunk://#diff-73d7a23e5015801b9bcc9db601d6ec9594d3eb34e5bb23154e0ae4b0c30f1a3bR1-R6)`)
* [`src/components/tabs/HeaderCustomTabPanel.tsx`](diffhunk://#diff-851b77f67c51af853bd14f685daa09e0c29caa979a80023735b310262ace5babR1-R29): Added a tab panel component (`HeaderCustomTabPanel`) for navigation within the app bar. (`[src/components/tabs/HeaderCustomTabPanel.tsxR1-R29](diffhunk://#diff-851b77f67c51af853bd14f685daa09e0c29caa979a80023735b310262ace5babR1-R29)`)
* [`src/components/layout/Header.tsx`](diffhunk://#diff-98816301f3cd7a2c4bf2a0408bd887f0fc83e4e02d7fe41afd966b7ccfe71a0aR1-R11): Introduced a `Header` component that incorporates the `ButtonAppBar`. (`[src/components/layout/Header.tsxR1-R11](diffhunk://#diff-98816301f3cd7a2c4bf2a0408bd887f0fc83e4e02d7fe41afd966b7ccfe71a0aR1-R11)`)

### Utility Enhancements:

* [`src/utils/emotion-cache.ts`](diffhunk://#diff-606254e63ac4388933ad231cd31e06af127a2e1a09931c3222bfb57920cc2ee1R1-R7): Added a utility to create an Emotion cache for styling. (`[src/utils/emotion-cache.tsR1-R7](diffhunk://#diff-606254e63ac4388933ad231cd31e06af127a2e1a09931c3222bfb57920cc2ee1R1-R7)`)